### PR TITLE
Add --platforms argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ### About
 This script queries APIs for various freely-available intelligence platforms
 in order to gain important context and reputation data for IP addresses and/or
-domains.  
+domains.
 
 ---
 
@@ -26,8 +26,8 @@ domains.
 * Shodan
 
 If you do not wish to create an account to get an API key for these platforms,
-you can comment out their functions at the end of the code and just use the
-data from WHOIS, AlienVault, Robtex, and IP Info.
+you can use the `--platforms` argument to only enable the platforms you want
+to use.
 
 
 #### Installation and Requirements


### PR DESCRIPTION
Allow users to specify which platforms they want to run.
Update `README` to include the `--platforms` argument.
When passing in a file, only stop checking after 5 targets if the user
enabled VirusTotal.
Indent error message for Shodan so the output is consistent.
Add a TODO to be fixed later.