### PR TITLE
Replace `--ipaddress` and `--domain` with `--target`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,10 @@ $ investigate
 
 
 #### Example Usage
-Python Hunt can take single IPs as command line argument with `-i` or `--ipaddress`.
+Python Hunt can perform a lookup for an IP addresse and domain:
 ```bash
-$ investigate -i 95.217.163.246
-```
-
-It can also perform a lookup for domains with `-d` or `--domain` flags.
-```bash
-$ investigate -d apple.com
+$ investigate -t 95.217.163.246
+$ investigate -t apple.com
 ```
 Finally, it can check a file for a list of IPs or Domains.
 You may mix types in the file, but they must be 1 per line.
@@ -79,7 +75,7 @@ By default, if no platform is specified, the script will run through all
 of them.
 
 ```bash
-$ investigate -i 165.254.239.130 -p ipinfo
+$ investigate -t 165.254.239.130 -p ipinfo
 ```
 Or
 ```bash
@@ -89,7 +85,7 @@ $ investigate -f IoC_file.txt -p otx shodan
 #### Example Output
 
 ```bash
-$ investigate -i 193.34.167.111
+$ investigate -t 193.34.167.111
 _________________________________________
 
     Investigating 193.34.167.111:
@@ -159,7 +155,7 @@ _________________________________________
 ---
 
 ```bash
-$ investigate -d creditkarma.com
+$ investigate -t creditkarma.com
 __________________________________________________
 
     Investigating Domain "creditkarma.com"
@@ -210,7 +206,7 @@ __________________________________________________
 ---
 
 ```bash
-$ investigate -i 165.254.239.130 -p ipinfo robtex
+$ investigate -t 165.254.239.130 -p ipinfo robtex
 _________________________________________
 
     Investigating 165.254.239.130:


### PR DESCRIPTION
This simplifies the interface, no need for the user to switch arguments,
the script will figure it out itself just like it does with the values
in the file passed with the `--file` argument.

Factorize the code a bit more:
* Added `get_args()` to handle argument parsing
* Added `check_targets()` to handle checking targets

This helps keep the `main()` function short and clean.
It also now allows users to easily call this script without using the
CLI, by writing a new python script:
```
from investigate import SHODAN, WHOIS, check_targets

check_targets(["abc.com", "1.2.3.4"], [SHODAN, WHOIS])
```

Move the `ip_check()` and `domain_check()` functions to be next to
`check_targets()`, I think it makes more sense than having those all the
way at the bottom while the other functions related to those are at the
top.